### PR TITLE
Fix arguments error with ruby 3

### DIFF
--- a/lib/journald/classes/trace_logger.rb
+++ b/lib/journald/classes/trace_logger.rb
@@ -1,7 +1,7 @@
 module Journald
   class TraceLogger
     def initialize(progname = nil, min_priority = nil, **tags)
-      @wrapped_logger = ::Journald::Logger.new(progname, min_priority, tags)
+      @wrapped_logger = ::Journald::Logger.new(progname, min_priority, **tags)
     end
 
     PASSTHROUGH_METHODS = [


### PR DESCRIPTION
We use this gem with Redmine. Redmine supports ruby 3 (maybe foreman supports it, too).